### PR TITLE
Remote Check Deposit: Batch Selection Grid Performance Updates

### DIFF
--- a/RockWeb/Plugins/com_bemaservices/RemoteCheckDeposit/RemoteDepositExport.ascx
+++ b/RockWeb/Plugins/com_bemaservices/RemoteCheckDeposit/RemoteDepositExport.ascx
@@ -35,7 +35,7 @@
                                 <Rock:DateField DataField="BatchStartDateTime" HeaderText="Date" SortExpression="BatchStartDateTime" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right" />
                                 <Rock:RockBoundField DataField="Name" HeaderText="Title" SortExpression="Name" />
                                 <Rock:RockBoundField DataField="TransactionCount" HeaderText="Transaction Count" SortExpression="TransactionCount" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right" />
-                                <Rock:CurrencyField DataField="TransactionAmount" HeaderText="Transaction Total" SortExpression="TransactionAmount" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right" />
+                                <Rock:CurrencyField DataField="TransactionAmount" HeaderText="Batch Total" SortExpression="TransactionAmount" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right" />
                                 <Rock:RockTemplateField HeaderText="Variance" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right">
                                     <ItemTemplate>
                                         <span class='<%# (decimal)Eval("Variance") != 0 ? "label label-danger" : "" %>'><%# this.FormatValueAsCurrency((decimal)Eval("Variance")) %></span>

--- a/RockWeb/Plugins/com_bemaservices/RemoteCheckDeposit/RemoteDepositExport.ascx
+++ b/RockWeb/Plugins/com_bemaservices/RemoteCheckDeposit/RemoteDepositExport.ascx
@@ -28,7 +28,7 @@
                             <Rock:RockDropDownList ID="ddlDeposited" runat="server" Label="Deposited" />
                         </Rock:GridFilter>
 
-                        <Rock:Grid ID="gBatches" runat="server" OnGridRebind="gBatches_GridRebind" OnRowCreated="gBatches_RowCreated">
+                        <Rock:Grid ID="gBatches" runat="server" OnGridRebind="gBatches_GridRebind" >
                             <Columns>
                                 <Rock:SelectField />
                                 <Rock:RockBoundField DataField="Id" HeaderText="Id" SortExpression="Id" HeaderStyle-HorizontalAlign="Right" ItemStyle-HorizontalAlign="Right" />


### PR DESCRIPTION
Remove a lot of useless class structure left over from the batch list block that was copied over. 

Goal was to increase performance when dealing with a ton of transactions in one batch, like upwards of 5000/batch. Got this to work pretty well: when using 50/page with lots of transactions, we were seeing less than 3 seconds load time.

If this isn't to the clients liking still, I also created a block setting that disables transaction tracking on the batch selection grid; so basically no transaction counts and no variance columns. Just the batch information. 

If a client really wants those details, they can be re-enabled in the block settings. I doubt they will miss them however; most of the variance stuff is taking care of under the finance pages. 