### PR TITLE
Wumc 1.10.3 pastoral care plugin feature request

### DIFF
--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
@@ -58,6 +58,7 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
     {
         #region Properties
         public int? _careTypeId = null;
+        public int? _personId = null;
         public List<CareTypeItem> ItemsState { get; set; }
         public List<AttributeCache> AvailableAttributes { get; set; }
 
@@ -113,9 +114,6 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
 
             // Get the careType id of the careType that user navigated from 
             _careTypeId = PageParameter( "CareTypeId" ).AsIntegerOrNull();
-
-            // Get the Person Id of the Person that the user navigated From
-            _personId = PageParameter("PersonId").AsIntegerOrNull();
 
             // Get PersonId from Page Parameter if Navigated from Person Profile
             _personId = PageParameter("PersonId").AsIntegerOrNull();

--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
@@ -46,6 +46,9 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
 
     [LinkedPage( "Person Profile Page", "Page used for viewing a person's profile. If set a view profile button will show for each group member.", false, order: 0 )]
     [BadgesField( "Badges", "The person badges to display in this block.", false, "", "", 0 )]
+    
+    //Add setting to set set the request date time to the current date and time
+    [BooleanField("Default Request Time to Current Time", "Defaults the Reqest Date and Time to Current Date and Time", false,"",1)]
     public partial class CareItemDetail : PersonBlock, IDetailBlock, ICustomGridColumns
     {
         #region Properties
@@ -162,6 +165,15 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
             var careItemId = PageParameter( "CareItemId" ).AsInteger();
             nbErrorMessage.Visible = false;
             nbNoParameterMessage.Visible = false;
+
+              //Check block attribute value to set request to current time and sets the value
+            bool? setToCurrentTime = GetAttributeValue("DefaultRequestTimetoCurrentTime").AsBoolean();
+            if (setToCurrentTime == true)
+            {
+                dtpContactDate.SelectedDateTime = RockDateTime.Now;
+            }
+
+            
 
             if ( careItemId == 0 && PageParameter( "CareTypeId" ).AsIntegerOrNull() == null )
             {

--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
@@ -114,6 +114,20 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
             // Get the careType id of the careType that user navigated from 
             _careTypeId = PageParameter( "CareTypeId" ).AsIntegerOrNull();
 
+            // Get the Person Id of the Person that the user navigated From
+            _personId = PageParameter("PersonId").AsIntegerOrNull();
+
+             // Get PersonId from Page Parameter if Navigated from Person Profile and set Person Picker
+            _personId = PageParameter("PersonId").AsIntegerOrNull();
+
+            if (_personId.HasValue) {
+                using (var rockContext = new RockContext()) {
+                    var personService = new PersonService(rockContext);
+                    ppPerson.SetValue(personService.Get(_personId.Value));
+                }
+                    
+            }
+
             // Load the other careTypes user is authorized to view 
             cblCareTypes.Items.Clear();
             using ( var rockContext = new RockContext() )

--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
@@ -117,10 +117,10 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
             // Get the Person Id of the Person that the user navigated From
             _personId = PageParameter("PersonId").AsIntegerOrNull();
 
-             // Get PersonId from Page Parameter if Navigated from Person Profile and set Person Picker
+            // Get PersonId from Page Parameter if Navigated from Person Profile
             _personId = PageParameter("PersonId").AsIntegerOrNull();
 
-            if (_personId.HasValue) {
+            if (_personId.HasValue && _personId != 0) {
                 using (var rockContext = new RockContext()) {
                     var personService = new PersonService(rockContext);
                     ppPerson.SetValue(personService.Get(_personId.Value));

--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemDetail.ascx.cs
@@ -49,6 +49,11 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
     
     //Add setting to set set the request date time to the current date and time
     [BooleanField("Default Request Time to Current Time", "Defaults the Reqest Date and Time to Current Date and Time", false,"",1)]
+
+    //Add option to enable self selection in the requester person pickers
+    [BooleanField("Allow Requester Self Selection", "Allows the person filling out the form to select themselves as the requestor", false,"",2)]
+
+
     public partial class CareItemDetail : PersonBlock, IDetailBlock, ICustomGridColumns
     {
         #region Properties
@@ -173,7 +178,9 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
                 dtpContactDate.SelectedDateTime = RockDateTime.Now;
             }
 
-            
+            //Checks the block attribute eto allow Requester self selection 
+            bool enbleSelfSelection = GetAttributeValue("AllowRequesterSelfSelection").AsBoolean();
+            ppContactorEdit.EnableSelfSelection = enbleSelfSelection;
 
             if ( careItemId == 0 && PageParameter( "CareTypeId" ).AsIntegerOrNull() == null )
             {

--- a/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemList.ascx.cs
+++ b/RockWeb/Plugins/com_bemaservices/PastoralCare/CareItemList.ascx.cs
@@ -317,7 +317,20 @@ namespace RockWeb.Plugins.com_bemaservices.PastoralCare
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void gItems_Add( object sender, EventArgs e )
         {
-            NavigateToLinkedPage( "DetailPage", "CareItemId", 0, "CareTypeId", SelectedTypeId );
+            string personId; 
+            if (_person != null) {
+                personId = _person.Id.ToString();
+            } else {
+                personId = "0";
+            }
+        
+            NavigateToLinkedPage("DetailPage", new Dictionary<string, string> {
+                { "CareItemId", "0" },
+                { "CareTypeId", SelectedTypeId.ToString() },
+                { "PersonId", personId }
+                
+            });
+        
         }
 
         /// <summary>


### PR DESCRIPTION
Added to Care Item Detail Block Settings to set the request date of new items to the current date and a setting to allow requestor self-selection in the person picker.

Pass Person Id as Page Parameter from care item list if on the person profile page and update the care item detail block to fill the person picker if person Id. If there was a better way to do this, I would love to go over it with you and learn.

